### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/S3DFX-CYBER/AI-Cyber-Defender/security/code-scanning/1](https://github.com/S3DFX-CYBER/AI-Cyber-Defender/security/code-scanning/1)

In general, the fix is to explicitly define the minimal required `GITHUB_TOKEN` permissions either at the workflow root (applies to all jobs) or per job. Since this workflow only runs tests and does not need to write to the repository or to other resources via `GITHUB_TOKEN`, we can safely set `contents: read` at the workflow level. This documents the intended access and ensures that even if org/repo defaults are broad, this workflow remains restricted.

The best fix here is to add a `permissions` block at the top level of `.github/workflows/ci.yml`, alongside `name` and `on`. Place it after the `name: CI` line for clarity. Set `permissions: contents: read`, which aligns with the minimal suggestion from CodeQL and supports actions/checkout while preventing write access. No other steps in the job require broader scopes like `pull-requests: write`, so we do not grant them.

Concretely:
- Edit `.github/workflows/ci.yml`.
- After line 1 (`name: CI`), insert:
  ```yaml
  permissions:
    contents: read
  ```
- Leave the rest of the workflow unchanged; no additional imports, methods, or definitions are needed since this is purely a configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow permissions to enhance security controls and restrict repository access during automated runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->